### PR TITLE
Fixed 2 recursion issues

### DIFF
--- a/bin/jsindex
+++ b/bin/jsindex
@@ -51,12 +51,12 @@ if (empty($src)) {
 
 $indexer = new \cebe\jssearch\Indexer();
 
-$files = [];
 foreach($src as $dir) {
-	$files = array_merge($files, findFiles($dir));
+	echo "Processing $dir\n";
+	$files = findFiles($dir);
 
 	if (empty($files)) {
-		error("No files where found in $dir.");
+		echo("No files where found in $dir.");
 	}
 
 	$indexer->indexFiles($files, $dir);
@@ -119,12 +119,12 @@ function findFiles($dir, $ext = '.html')
 			continue;
 		}
 		$path = $dir . DIRECTORY_SEPARATOR . $file;
-		if (substr($file, -($l = strlen($ext)), $l) === $ext) {
-			if (is_file($path)) {
+		if (is_file($path)) {
+			if (substr($file, -($l = strlen($ext)), $l) === $ext) {
 				$list[] = $path;
-			} else {
-				$list = array_merge($list, findFiles($path, $ext));
-			}
+			} 
+		} else {
+			$list = array_merge($list, findFiles($path, $ext));
 		}
 	}
 	closedir($handle);

--- a/bin/jsindex
+++ b/bin/jsindex
@@ -56,10 +56,10 @@ foreach($src as $dir) {
 	$files = findFiles($dir);
 
 	if (empty($files)) {
-		echo("No files where found in $dir.");
+		echo("No files where found in $dir.\n");
+	} else {
+		$indexer->indexFiles($files, $dir);
 	}
-
-	$indexer->indexFiles($files, $dir);
 }
 
 $js = $indexer->exportJs();

--- a/lib/Indexer.php
+++ b/lib/Indexer.php
@@ -65,7 +65,7 @@ class Indexer
 			$title = '<i>No title</i>';
 		}
 		return [
-			'url' => $baseUrl . str_replace('\\', '/', substr($file, strlen(rtrim($basePath, '\\/')))),
+			'url' => $baseUrl . str_replace('\\', '/', substr($file, strlen(rtrim($basePath, '\\/'))+1)),
 			'title' => $title,
 		];
 	}


### PR DESCRIPTION
Hi,

I fixed 2 issues in the jsindex file:
- multiple paths on the command line would cause a growing list of files which would be processed in the loop repeatedly; so either start with a clean files list each step (which I did) or pull the call to the indexer out of the loop (which can not be done easy because it requires the $dir variable)
- the loop checking if files are html or subdirectories to process was inside out causing it to only process subdirectories whose name ended in "html" - so effectively this did not process a whole directory tree as it was supposed to.